### PR TITLE
Secure access established

### DIFF
--- a/go/controller/redirect.go
+++ b/go/controller/redirect.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"log"
+	"regexp"
+)
+
+
+// RedirectHTTP is an HTTP handler (suitable for use with http.HandleFunc)
+// that responds to all requests by redirecting to the same URL served over HTTPS.
+// It should only be invoked for requests received over HTTP.
+func RedirectHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.TLS != nil || r.Host == "" {
+		http.Error(w, "not found", 404)
+	}
+
+	var u *url.URL
+	u = r.URL
+	host := r.Host
+	u.Host = strings.Split(host, ":")[0]
+	u.Scheme = "https"
+	log.Printf("redirect to u.host  %s -> %s\n", r.Host, u.String())
+	http.Redirect(w, r, u.String(), 302)
+}
+
+// interne Aufrufe vom gleichen lokalen Netz mit Mux annehmen, sonst redirect auf HTTPS
+type HandlerSwitch struct {
+	Mux      http.Handler
+	Redirect http.Handler
+}
+
+// nicht richtig für 172.16.0.0/12
+var matcher = regexp.MustCompile("(192\\.168.*)|(localhost)|(10\\..*)|(172\\..*)")
+
+// Handler function, die Internetzugriffe auf den Redirect Handler umleitet.
+// Lokale Zugriffe werden direkt von MUX geroutet
+func (h *HandlerSwitch) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	local := matcher.MatchString(host)
+	if local {
+		h.Mux.ServeHTTP(w, r)
+	} else {
+		h.Redirect.ServeHTTP(w, r)
+	}
+}

--- a/go/controller/routing.go
+++ b/go/controller/routing.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
+	"net/http"
+	"os"
+	"github.com/justinas/nosurf"
+	"github.com/geobe/gostip/go/model"
+	"fmt"
+)
+
+const pagedir = model.Base + "/pages/"
+const resourcedir = model.Base + "/resources/"
+
+func err(writer http.ResponseWriter, request *http.Request) {
+	//error := request.Header.Get("Status")
+	fmt.Fprintf(writer, "Error with path %s",
+		request.URL.Path[1:])
+}
+
+func SetRouting() *mux.Router {
+	mux := mux.NewRouter()
+	// finde Working directory = GOPATH
+	docbase, _ := os.Getwd()
+	docbase += "/"
+	// FileServer ist ein Handler, der dieses Verzeichnis bedient
+	// Funktionsvariablen für alice anlegen
+	files := http.StripPrefix("/pages/", http.FileServer(http.Dir(docbase + pagedir)))
+	resources := http.FileServer(http.Dir(docbase + resourcedir))
+	pages := http.FileServer(http.Dir(docbase + pagedir))
+
+	requestLogging := alice.New(RequestLogger)
+	csrfChecking := alice.New(nosurf.NewPure)
+	resultsChecking := alice.New(RequestLogger, nosurf.NewPure, SessionChecker, AuthProjectOffice)
+	enroleChecking := alice.New(RequestLogger, nosurf.NewPure, SessionChecker, AuthEnrol)
+	anyChecking := alice.New(RequestLogger, nosurf.NewPure, SessionChecker, AuthAny)
+
+	// Zugriff auf das Verzeichnis via Präfic /pages/
+	mux.PathPrefix("/pages/").Handler(requestLogging.Then(files))
+	// Zugriff auf die Resourcen-Verzeichnisse mit regular expression
+	mux.PathPrefix("/{dir:(?:css|fonts|js|images)}/").Handler(requestLogging.Then(resources))
+	// Zugriff auf *.htm[l] Dateien im /pages Verzeichnis
+	mux.Handle("/{dir:\\w+\\.html?}", requestLogging.Then(pages))
+	// error
+	mux.HandleFunc("/err", err)
+	// index
+	mux.Handle("/", csrfChecking.ThenFunc(HandleIndex))
+	mux.Handle("/index", csrfChecking.ThenFunc(HandleIndex))
+	// login
+	mux.Handle("/login", csrfChecking.ThenFunc(HandleLogin))
+	// logout
+	mux.HandleFunc("/logout", HandleLogout)
+	// work
+	mux.Handle("/work", anyChecking.ThenFunc(HandleWork))
+	// find
+	mux.Handle("/find/applicant", enroleChecking.ThenFunc(FindApplicant))
+	// show results edit form
+	mux.Handle("/results/show", resultsChecking.ThenFunc(ShowResults))
+	// submit results edit form
+	mux.Handle("/results/submit", resultsChecking.ThenFunc(SubmitResults))
+	// show enrol form
+	mux.Handle("/enrol/show", enroleChecking.ThenFunc(ShowEnrol))
+	// process enrol form
+	mux.Handle("/enrol/submit", enroleChecking.ThenFunc(SubmitEnrol))
+	// show cancellation form
+	mux.Handle("/cancellation/show", enroleChecking.ThenFunc(ShowCancellation))
+	// process cancellation form
+	mux.Handle("/cancellation/submit", enroleChecking.ThenFunc(SubmitCancelation))
+	// process edit form
+	mux.Handle("/edit/submit", enroleChecking.ThenFunc(SubmitApplicantEdit))
+	// register
+	mux.Handle("/register", csrfChecking.ThenFunc(ShowRegistration))
+	// register
+	mux.Handle("/register/submit", csrfChecking.ThenFunc(SubmitRegistration))
+	return mux
+}

--- a/go/model/setup.go
+++ b/go/model/setup.go
@@ -43,7 +43,8 @@ func Db() *gorm.DB {
 func ConnectDb() *gorm.DB {
 	db, err := gorm.Open(viper.GetString("db.type"), viper.GetString("db.connect"))
 	if err != nil {
-		panic("failed to connect database")
+		fmt.Errorf("db error is %s", err)
+		panic("failed to connect database with err " + fmt.Sprint(err))
 	}
 	return db
 }

--- a/go/server/devserv.go
+++ b/go/server/devserv.go
@@ -8,11 +8,12 @@ import (
 	//"net"
 	"net/url"
 	"strings"
+	"regexp"
 )
 
 const httpport = ":8070"
 const tlsport = ":8090"
-const schema  = "http"
+const schema = "http"
 
 func main() {
 	// prepare database
@@ -30,10 +31,16 @@ func main() {
 		Handler: mux,
 	}
 
+	// switching redirect handler
+	handlerSwitch := &HandlerSwitch{
+		Mux:    mux,
+		Redirect: http.HandlerFunc(RedirectHTTP),
+	}
+
 	// konfiguriere redirect server
 	redirectserver := &http.Server{
 		Addr:    "0.0.0.0" + httpport,
-		Handler: http.HandlerFunc(RedirectHTTP),
+		Handler: handlerSwitch, //http.HandlerFunc(RedirectHTTP),
 	}
 	// starte den redirect server
 	go redirectserver.ListenAndServe()
@@ -59,4 +66,22 @@ func RedirectHTTP(w http.ResponseWriter, r *http.Request) {
 	u.Scheme = schema
 	log.Printf("redirect to u.host  %s -> %s\n", r.Host, u.String())
 	http.Redirect(w, r, u.String(), 302)
+}
+
+type HandlerSwitch struct {
+	Mux      http.Handler
+	Redirect http.Handler
+}
+
+// nicht richtig für 172.16.0.0/12
+var matcher = regexp.MustCompile("(192\\.168.*)|(localhost)|(10\\..*)|(172\\..*)")
+
+func (h *HandlerSwitch) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	local := matcher.MatchString(host)
+	if local {
+		h.Mux.ServeHTTP(w, r)
+	} else {
+		h.Redirect.ServeHTTP(w, r)
+	}
 }

--- a/go/server/devserv.go
+++ b/go/server/devserv.go
@@ -1,25 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"github.com/geobe/gostip/go/controller"
 	"github.com/geobe/gostip/go/model"
-	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
 	"net/http"
-	"os"
-	"github.com/justinas/nosurf"
 	"log"
 )
-
-const pagedir = model.Base + "/pages/"
-const resourcedir = model.Base + "/resources/"
-
-func err(writer http.ResponseWriter, request *http.Request) {
-	//error := request.Header.Get("Status")
-	fmt.Fprintf(writer, "Error with path %s",
-		request.URL.Path[1:])
-}
 
 func main() {
 	// prepare database
@@ -29,59 +15,7 @@ func main() {
 	model.ClearTestDb(db)
 	model.InitTestDb(db)
 
-	mux := mux.NewRouter()
-	// finde Working directory = GOPATH
-	docbase, _ := os.Getwd()
-	docbase += "/"
-	// FileServer ist ein Handler, der dieses Verzeichnis bedient
-	// Funktionsvariablen für alice anlegen
-	files := http.StripPrefix("/pages/", http.FileServer(http.Dir(docbase + pagedir)))
-	resources := http.FileServer(http.Dir(docbase + resourcedir))
-	pages := http.FileServer(http.Dir(docbase + pagedir))
-
-	requestLogging := alice.New(controller.RequestLogger)
-	csrfChecking := alice.New(nosurf.NewPure)
-	resultsChecking := alice.New(controller.RequestLogger, nosurf.NewPure, controller.SessionChecker, controller.AuthProjectOffice)
-	enroleChecking := alice.New(controller.RequestLogger, nosurf.NewPure, controller.SessionChecker, controller.AuthEnrol)
-	anyChecking := alice.New(controller.RequestLogger, nosurf.NewPure, controller.SessionChecker, controller.AuthAny)
-
-	// Zugriff auf das Verzeichnis via Präfic /pages/
-	mux.PathPrefix("/pages/").Handler(requestLogging.Then(files))
-	// Zugriff auf die Resourcen-Verzeichnisse mit regular expression
-	mux.PathPrefix("/{dir:(?:css|fonts|js|images)}/").Handler(requestLogging.Then(resources))
-	// Zugriff auf *.htm[l] Dateien im /pages Verzeichnis
-	mux.Handle("/{dir:\\w+\\.html?}", requestLogging.Then(pages))
-	// error
-	mux.HandleFunc("/err", err)
-	// index
-	mux.Handle("/", csrfChecking.ThenFunc(controller.HandleIndex))
-	mux.Handle("/index", csrfChecking.ThenFunc(controller.HandleIndex))
-	// login
-	mux.Handle("/login", csrfChecking.ThenFunc(controller.HandleLogin))
-	// logout
-	mux.HandleFunc("/logout", controller.HandleLogout)
-	// work
-	mux.Handle("/work", anyChecking.ThenFunc(controller.HandleWork))
-	// find
-	mux.Handle("/find/applicant", enroleChecking.ThenFunc(controller.FindApplicant))
-	// show results edit form
-	mux.Handle("/results/show", resultsChecking.ThenFunc(controller.ShowResults))
-	// submit results edit form
-	mux.Handle("/results/submit", resultsChecking.ThenFunc(controller.SubmitResults))
-	// show enrol form
-	mux.Handle("/enrol/show", enroleChecking.ThenFunc(controller.ShowEnrol))
-	// process enrol form
-	mux.Handle("/enrol/submit", enroleChecking.ThenFunc(controller.SubmitEnrol))
-	// show cancellation form
-	mux.Handle("/cancellation/show", enroleChecking.ThenFunc(controller.ShowCancellation))
-	// process cancellation form
-	mux.Handle("/cancellation/submit", enroleChecking.ThenFunc(controller.SubmitCancelation))
-	// process edit form
-	mux.Handle("/edit/submit", enroleChecking.ThenFunc(controller.SubmitApplicantEdit))
-	// register
-	mux.Handle("/register", csrfChecking.ThenFunc(controller.ShowRegistration))
-	// register
-	mux.Handle("/register/submit", csrfChecking.ThenFunc(controller.SubmitRegistration))
+	mux := controller.SetRouting()
 
 	// konfiguriere server
 	server := &http.Server{

--- a/go/server/devserv.go
+++ b/go/server/devserv.go
@@ -5,7 +5,14 @@ import (
 	"github.com/geobe/gostip/go/model"
 	"net/http"
 	"log"
+	//"net"
+	"net/url"
+	"strings"
 )
+
+const httpport = ":8070"
+const tlsport = ":8090"
+const schema  = "http"
 
 func main() {
 	// prepare database
@@ -19,11 +26,37 @@ func main() {
 
 	// konfiguriere server
 	server := &http.Server{
-		//Addr: "127.0.0.1:8090",
-		Addr:    "0.0.0.0:8090",
+		Addr:    "0.0.0.0" + tlsport,
 		Handler: mux,
 	}
-	// und starte ihn
+
+	// konfiguriere redirect server
+	redirectserver := &http.Server{
+		Addr:    "0.0.0.0" + httpport,
+		Handler: http.HandlerFunc(RedirectHTTP),
+	}
+	// starte den redirect server
+	go redirectserver.ListenAndServe()
+
+	// und starte den primären server
+	log.Printf("server starting\n")
 	server.ListenAndServe()
-	log.Printf("server started\n")
+}
+
+
+// RedirectHTTP is an HTTP handler (suitable for use with http.HandleFunc)
+// that responds to all requests by redirecting to the same URL served over HTTPS.
+// It should only be invoked for requests received over HTTP.
+func RedirectHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.TLS != nil || r.Host == "" {
+		http.Error(w, "not found", 404)
+	}
+
+	var u *url.URL
+	u = r.URL
+	host := r.Host
+	u.Host = strings.Split(host, ":")[0] + tlsport
+	u.Scheme = schema
+	log.Printf("redirect to u.host  %s -> %s\n", r.Host, u.String())
+	http.Redirect(w, r, u.String(), 302)
 }


### PR DESCRIPTION
Secure access to the website is established using LetsEncrypt certificates. When accessed over a local private network on port `httpport` (preset to 8070), automatic redirect to https is suppressed to avoid https errors.
Remember to run `go get ...` after pulling these changes to get additional needed libraries from golang.org.x